### PR TITLE
更加的jquery一些

### DIFF
--- a/src/com/rpsg/gdxQuery/EventType.java
+++ b/src/com/rpsg/gdxQuery/EventType.java
@@ -1,0 +1,5 @@
+package com.rpsg.gdxQuery;
+
+public enum EventType {
+    CLICK, TOUCHUP, TOUCHDOWN
+}

--- a/src/com/rpsg/gdxQuery/GdxQuery.java
+++ b/src/com/rpsg/gdxQuery/GdxQuery.java
@@ -3,6 +3,7 @@ package com.rpsg.gdxQuery;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.function.Consumer;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -620,5 +621,23 @@ public class GdxQuery {
 			return ((Button)getItem()).isChecked();
 		return false;
 	}
+
+
+    public GdxQuery on(EventType eventType, Consumer<GdxQuery> func) {
+        GdxQuery handle = this;
+        Runnable runer = new Runnable() {
+            public void run() {
+                func.accept(handle);
+            }
+        };
+        switch(eventType) {
+        case CLICK:     this.onClick(runer);
+                        break;
+        case TOUCHUP:   this.onTouchUp(runer);
+                        break;
+        case TOUCHDOWN: this.onTouchDown(runer);
+        }
+        return this;
+    }
 
 }

--- a/src/com/rpsg/gdxQuery/gQuery/IGQuery.java
+++ b/src/com/rpsg/gdxQuery/gQuery/IGQuery.java
@@ -1,0 +1,19 @@
+package com.rpsg.gdxQuery.gQuery;
+
+import com.badlogic.gdx.graphics.Texture;
+import com.rpsg.gdxQuery.$;
+import com.rpsg.gdxQuery.GdxQuery;
+
+public interface IGQuery {
+    default GdxQuery $(String fileName) {
+        return $.image(fileName);
+    };
+
+    default GdxQuery $(Texture texture) {
+        return $.image(texture);
+    }
+
+    default GdxQuery $(GdxQuery... gdxQueries) {
+        return $.add(gdxQueries);
+    }
+}

--- a/src/demo/SimpleGdxQueryDemo.java
+++ b/src/demo/SimpleGdxQueryDemo.java
@@ -9,10 +9,12 @@ import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.rpsg.gdxQuery.$;
+import com.rpsg.gdxQuery.EventType;
 import com.rpsg.gdxQuery.GdxQuery;
 import com.rpsg.gdxQuery.GdxQueryRunnable;
+import com.rpsg.gdxQuery.gQuery.IGQuery;
 
-public class SimpleGdxQueryDemo implements ApplicationListener, InputProcessor {
+public class SimpleGdxQueryDemo implements ApplicationListener, InputProcessor, IGQuery{
 	public static void main(String[] args) {
 		new LwjglApplication(new SimpleGdxQueryDemo(),"demo",1024,576);
 	}
@@ -45,10 +47,16 @@ public class SimpleGdxQueryDemo implements ApplicationListener, InputProcessor {
 //			}
 //		});
 		
+		// v0.3 use method
 		$.add($.image("resource/data/badlogic.jpg"),$.image("resource/data/badlogic.jpg")).first().setColor(Color.RED).setPosition(50, 50).next().setColor(Color.GREEN).setPosition(200, 200).getFather().run(new GdxQueryRunnable() {
 			public void run(GdxQuery self) {
 				self.not(self.first());
 			}
+		}).appendTo(stage);
+		
+		//now use lambda, more  js like!!!
+		$("resource/data/badlogic.jpg").on(EventType.CLICK, (query)-> {
+		    System.out.println("hello");
 		}).appendTo(stage);
 	}
 	


### PR DESCRIPTION
用IGQuery接口重载封装$类
现在可以用$("path")或者$(gdxQuery1..gdxQueryn)代替原有的$.add $.image了，更加jquery化。
利用java8特性封装了runnable接口，同时实现on函数代替onClick, onTouchDown等。
阅读起来事件会是回调方式的而非new class， 更简洁易懂
$("resource/data/badlogic.jpg").on(EventType.CLICK, (query)-> {
     System.out.println("hello");
}).appendTo(stage)
